### PR TITLE
[T003] Stripe Checkout + webhook + session-from-checkout

### DIFF
--- a/core/api/__init__.py
+++ b/core/api/__init__.py
@@ -4,11 +4,13 @@ from django.http import FileResponse
 from ..models import Shard, TemporalGrant
 from .auth import router as auth_router
 from .grants import router as grants_router
+from .payments import router as payments_router
 
 api = NinjaAPI()
 
 api.add_router("/auth", auth_router)
 api.add_router("/grants", grants_router)
+api.add_router("/payments", payments_router)
 
 @api.get("/shards/validate/")
 def validate_shard(request, token: str):

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -1,6 +1,9 @@
 from django.contrib.auth import authenticate, login, logout
 from ninja import Router
-from ..schemas.auth import LoginIn, AuthResponse, UserOut, ErrorOut
+from ..models import Order
+from ..schemas.auth import LoginIn, AuthResponse, ErrorOut
+from ..schemas.payments import SessionFromCheckoutIn
+from ..services import payments as payments_service
 from django.http import HttpRequest
 
 router = Router()
@@ -19,3 +22,11 @@ def login_view(request: HttpRequest, data: LoginIn):
 def logout_view(request: HttpRequest):
     logout(request)
     return 204, None
+
+@router.post("/session-from-checkout", response={200: AuthResponse, 404: ErrorOut})
+def session_from_checkout(request: HttpRequest, data: SessionFromCheckoutIn):
+    try:
+        user = payments_service.login_from_session(request, data.session_id)
+    except Order.DoesNotExist:
+        return 404, {"detail": "order not found"}
+    return 200, {"user": user}

--- a/core/api/payments.py
+++ b/core/api/payments.py
@@ -1,0 +1,39 @@
+import stripe
+from django.http import HttpRequest
+from ninja import Router
+
+from ..schemas.auth import ErrorOut
+from ..schemas.payments import CreateCheckoutSessionIn, CreateCheckoutSessionOut
+from ..services import payments as payments_service
+
+router = Router()
+
+
+@router.post(
+    "/create-checkout-session",
+    response={200: CreateCheckoutSessionOut, 400: ErrorOut, 409: ErrorOut},
+)
+def create_checkout_session(request: HttpRequest, data: CreateCheckoutSessionIn):
+    try:
+        url = payments_service.create_session(data)
+    except payments_service.EmailAlreadyExists:
+        return 409, {"detail": "email already in use"}
+    except payments_service.BookNotFound:
+        return 400, {"detail": "unknown book"}
+    return 200, {"checkout_url": url}
+
+
+@router.post("/webhook", response={200: dict, 400: ErrorOut})
+def stripe_webhook(request: HttpRequest):
+    payload = request.body
+    signature = request.headers.get("Stripe-Signature", "")
+
+    try:
+        event = payments_service.verify_and_parse_event(payload, signature)
+    except (stripe.SignatureVerificationError, ValueError):
+        return 400, {"detail": "invalid signature"}
+
+    if event["type"] == "checkout.session.completed":
+        payments_service.fulfill_checkout(event["data"]["object"])
+
+    return 200, {}

--- a/core/schemas/payments.py
+++ b/core/schemas/payments.py
@@ -1,0 +1,20 @@
+from ninja import Schema
+
+from ..models import Order
+
+
+class CreateCheckoutSessionIn(Schema):
+    email: str
+    password: str
+    full_name: str
+    phone: str
+    book_slug: str
+    pace: str
+
+
+class CreateCheckoutSessionOut(Schema):
+    checkout_url: str
+
+
+class SessionFromCheckoutIn(Schema):
+    session_id: str

--- a/core/services/grants.py
+++ b/core/services/grants.py
@@ -1,0 +1,14 @@
+from ..models import Order, TemporalGrant
+
+
+def create_for_order(order: Order) -> list[TemporalGrant]:
+    """Create the chapter-1 grant immediately and schedule chapters 2..N.
+
+    Returns the full list of grants ordered by chapter.order_index.
+    The caller (the Stripe webhook) takes the first grant and hands it to
+    `whatsapp.send_chapter` for the immediate chapter-1 send.
+
+    Implemented in T004 (cadence scheduler). Until then this raises so that
+    fulfillment failures during prototype testing are loud, not silent.
+    """
+    raise NotImplementedError("T004 cadence scheduler not yet implemented")

--- a/core/services/payments.py
+++ b/core/services/payments.py
@@ -1,0 +1,119 @@
+import logging
+
+import stripe
+from django.conf import settings
+from django.contrib.auth import login as auth_login
+from django.contrib.auth.hashers import make_password
+from django.db import transaction
+from django.http import HttpRequest
+
+from ..models import Book, Order, User
+from ..schemas.payments import CreateCheckoutSessionIn
+from . import grants as grants_service
+from . import whatsapp as whatsapp_service
+
+logger = logging.getLogger(__name__)
+
+
+class EmailAlreadyExists(Exception):
+    """Signals 409 from the create-checkout-session endpoint."""
+
+
+class BookNotFound(Exception):
+    """Signals 400 from the create-checkout-session endpoint."""
+
+
+def create_session(payload: CreateCheckoutSessionIn) -> str:
+    """Create a Stripe Checkout Session for `payload` and return its hosted URL."""
+    if User.objects.filter(email=payload.email).exists():
+        raise EmailAlreadyExists()
+
+    try:
+        book = Book.objects.get(slug=payload.book_slug)
+    except Book.DoesNotExist as exc:
+        raise BookNotFound() from exc
+
+    stripe.api_key = settings.STRIPE_API_KEY
+    session = stripe.checkout.Session.create(
+        mode="payment",
+        line_items=[{
+            "price_data": {
+                "currency": "usd",
+                "product_data": {"name": book.title},
+                "unit_amount": book.price_cents,
+            },
+            "quantity": 1,
+        }],
+        success_url=f"{settings.FRONTEND_URL}/welcome?session_id={{CHECKOUT_SESSION_ID}}",
+        cancel_url=f"{settings.FRONTEND_URL}/?book_id={book.slug}",
+        metadata={
+            "email": payload.email,
+            "password_hash": make_password(payload.password),
+            "full_name": payload.full_name,
+            "phone": payload.phone,
+            "book_slug": payload.book_slug,
+            "pace": payload.pace,
+        },
+    )
+    return session.url
+
+
+def verify_and_parse_event(payload: bytes, signature: str) -> dict:
+    """Verify the Stripe-Signature header and return the parsed event dict."""
+    return stripe.Webhook.construct_event(
+        payload=payload,
+        sig_header=signature,
+        secret=settings.STRIPE_WEBHOOK_SECRET,
+    )
+
+
+def fulfill_checkout(session: dict) -> Order:
+    """Idempotently create User+Order+chapter-1 grant for a completed checkout.
+
+    Per Q5 lock: User+Order+grant are atomic; the chapter-1 WhatsApp send
+    runs post-commit and is best-effort (logged on failure, never blocks
+    the 200 to Stripe).
+    """
+    session_id = session["id"]
+
+    existing = Order.objects.filter(stripe_session_id=session_id).first()
+    if existing is not None:
+        return existing
+
+    metadata = session["metadata"]
+    book = Book.objects.get(slug=metadata["book_slug"])
+    amount_cents = session.get("amount_total") or book.price_cents
+
+    with transaction.atomic():
+        user = User(
+            email=metadata["email"],
+            full_name=metadata["full_name"],
+            phone=metadata["phone"],
+            password=metadata["password_hash"],
+        )
+        user.save()
+
+        order = Order.objects.create(
+            user=user,
+            book=book,
+            pace=metadata["pace"],
+            stripe_session_id=session_id,
+            amount_cents=amount_cents,
+        )
+
+        created_grants = grants_service.create_for_order(order)
+
+    if created_grants:
+        try:
+            whatsapp_service.send_chapter(created_grants[0])
+        except Exception:
+            logger.exception("WhatsApp chapter-1 send failed for order %s", order.id)
+
+    return order
+
+
+def login_from_session(request: HttpRequest, session_id: str) -> User:
+    """Look up Order by Stripe session_id and log its user in via Django session."""
+    order = Order.objects.select_related("user").get(stripe_session_id=session_id)
+    auth_login(request, order.user)
+    return order.user

--- a/core/services/whatsapp.py
+++ b/core/services/whatsapp.py
@@ -1,0 +1,11 @@
+from ..models import TemporalGrant
+
+
+def send_chapter(grant: TemporalGrant) -> None:
+    """Send the WhatsApp message for `grant`'s chapter to grant.user.phone.
+
+    Implemented in T005 (Twilio WhatsApp delivery). Called by the Stripe
+    webhook AFTER the fulfillment transaction commits, wrapped in a
+    best-effort try/except per Q5 of T003 grilling.
+    """
+    raise NotImplementedError("T005 Twilio WhatsApp delivery not yet implemented")

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch, MagicMock
+
+import stripe
+
+from django.contrib.auth.hashers import check_password, identify_hasher
 from django.test import TestCase, Client
 from django.urls import reverse
 from .models import User, Book, Chapter, Shard, Order, TemporalGrant
@@ -228,3 +233,216 @@ class GrantsApiTests(TestCase):
         self.assertEqual(response.status_code, 403)
         self.grant.refresh_from_db()
         self.assertIsNone(self.grant.opened_at)
+
+
+class PaymentsApiTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.book = Book.objects.create(
+            title="Pathfinder Codex",
+            slug="pathfinder",
+            price_cents=2500,
+        )
+        self.payload = {
+            "email": "buyer@example.com",
+            "password": "SuperSecret123!",
+            "full_name": "New Reader",
+            "phone": "+15551234567",
+            "book_slug": "pathfinder",
+            "pace": "steady",
+        }
+
+    def _fake_session(self, session_id):
+        return {
+            "id": session_id,
+            "amount_total": 2500,
+            "metadata": {
+                "email": "buyer@example.com",
+                "password_hash": "hashed-pw-blob",
+                "full_name": "New Reader",
+                "phone": "+15551234567",
+                "book_slug": "pathfinder",
+                "pace": "steady",
+            },
+        }
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_session_returns_url(self, mock_create):
+        mock_create.return_value = MagicMock(url="https://checkout.stripe.com/c/pay/cs_test_123")
+        response = self.client.post(
+            "/api/payments/create-checkout-session",
+            data=json.dumps(self.payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"checkout_url": "https://checkout.stripe.com/c/pay/cs_test_123"},
+        )
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_session_hashes_password_in_metadata(self, mock_create):
+        mock_create.return_value = MagicMock(url="https://stripe.example/x")
+        self.client.post(
+            "/api/payments/create-checkout-session",
+            data=json.dumps(self.payload),
+            content_type="application/json",
+        )
+        metadata = mock_create.call_args.kwargs["metadata"]
+        self.assertNotIn(self.payload["password"], json.dumps(metadata))
+        self.assertNotEqual(metadata["password_hash"], self.payload["password"])
+        identify_hasher(metadata["password_hash"])  # raises if unrecognized
+        self.assertTrue(check_password(self.payload["password"], metadata["password_hash"]))
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_session_duplicate_email_409(self, mock_create):
+        User.objects.create_user(
+            email="buyer@example.com",
+            password="anything",
+            full_name="Existing",
+            phone="+15551110000",
+        )
+        response = self.client.post(
+            "/api/payments/create-checkout-session",
+            data=json.dumps(self.payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 409)
+        mock_create.assert_not_called()
+
+    @patch("stripe.checkout.Session.create")
+    def test_create_session_unknown_book_400(self, mock_create):
+        bad = dict(self.payload, book_slug="no-such-book")
+        response = self.client.post(
+            "/api/payments/create-checkout-session",
+            data=json.dumps(bad),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_create.assert_not_called()
+
+    @patch("core.services.grants.create_for_order")
+    @patch("core.services.whatsapp.send_chapter")
+    @patch("stripe.Webhook.construct_event")
+    def test_webhook_completed_creates_user_and_order(self, mock_event, mock_send, mock_grants):
+        mock_grants.return_value = []
+        mock_event.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": self._fake_session("cs_test_abc")},
+        }
+        response = self.client.post(
+            "/api/payments/webhook",
+            data=b"{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=fake",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.filter(email="buyer@example.com").exists())
+        order = Order.objects.get(stripe_session_id="cs_test_abc")
+        self.assertEqual(order.book, self.book)
+        self.assertEqual(order.pace, "steady")
+        self.assertEqual(order.amount_cents, 2500)
+        mock_send.assert_not_called()
+
+    @patch("core.services.grants.create_for_order")
+    @patch("core.services.whatsapp.send_chapter")
+    @patch("stripe.Webhook.construct_event")
+    def test_webhook_idempotent_replay_noops(self, mock_event, _mock_send, mock_grants):
+        mock_grants.return_value = []
+        mock_event.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": self._fake_session("cs_test_dup")},
+        }
+        for _ in range(2):
+            response = self.client.post(
+                "/api/payments/webhook",
+                data=b"{}",
+                content_type="application/json",
+                HTTP_STRIPE_SIGNATURE="t=1,v1=fake",
+            )
+            self.assertEqual(response.status_code, 200)
+        self.assertEqual(User.objects.filter(email="buyer@example.com").count(), 1)
+        self.assertEqual(Order.objects.filter(stripe_session_id="cs_test_dup").count(), 1)
+        # Replay short-circuits BEFORE create_for_order is called again.
+        self.assertEqual(mock_grants.call_count, 1)
+
+    @patch("stripe.Webhook.construct_event")
+    def test_webhook_invalid_signature_400(self, mock_event):
+        mock_event.side_effect = stripe.SignatureVerificationError("bad sig", "sig")
+        response = self.client.post(
+            "/api/payments/webhook",
+            data=b"{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=fake",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "invalid signature")
+
+    @patch("core.services.grants.create_for_order")
+    @patch("core.services.whatsapp.send_chapter")
+    @patch("stripe.Webhook.construct_event")
+    def test_webhook_whatsapp_failure_does_not_block_200(self, mock_event, mock_send, mock_grants):
+        shard = Shard.objects.create(title="Ch1 shard", slug="ch1-shard")
+        Chapter.objects.create(book=self.book, order_index=1, title="Ch1", shard=shard)
+
+        def _make_grants(order):
+            return [TemporalGrant.objects.create(
+                user=order.user,
+                shard=shard,
+                expires_at=timezone.now() + timedelta(days=1),
+            )]
+
+        mock_grants.side_effect = _make_grants
+        mock_send.side_effect = RuntimeError("twilio outage")
+        mock_event.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": self._fake_session("cs_test_wa_fail")},
+        }
+        response = self.client.post(
+            "/api/payments/webhook",
+            data=b"{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=fake",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Order.objects.filter(stripe_session_id="cs_test_wa_fail").exists())
+        mock_send.assert_called_once()
+
+
+class SessionFromCheckoutTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.book = Book.objects.create(
+            title="Pathfinder Codex", slug="pathfinder", price_cents=2500,
+        )
+        self.user = User.objects.create_user(
+            email="buyer@example.com",
+            password="anything",
+            full_name="New Reader",
+            phone="+15551234567",
+        )
+        self.order = Order.objects.create(
+            user=self.user,
+            book=self.book,
+            pace="steady",
+            stripe_session_id="cs_test_logmein",
+            amount_cents=2500,
+        )
+
+    def test_session_from_checkout_logs_in_user(self):
+        response = self.client.post(
+            "/api/auth/session-from-checkout",
+            data=json.dumps({"session_id": "cs_test_logmein"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["user"]["email"], "buyer@example.com")
+        self.assertIn("sessionid", response.cookies)
+
+    def test_session_from_checkout_unknown_session_404(self):
+        response = self.client.post(
+            "/api/auth/session-from-checkout",
+            data=json.dumps({"session_id": "cs_test_no_such"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=6.0,<7.0
+django-ninja>=1.6,<2.0
+django-cors-headers>=4.9,<5.0
+shortuuid>=1.0,<2.0
+stripe>=12.0,<13.0

--- a/sapien_backend/settings.py
+++ b/sapien_backend/settings.py
@@ -1,8 +1,14 @@
+import os
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = 'django-insecure-!m(-3)1zz6uzjf9iszoe6-#u@&^b5s&3kq6&#g%h@ia)z0@gr8'
+
+# Stripe
+STRIPE_API_KEY = os.environ.get("STRIPE_API_KEY", "")
+STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
 
 DEBUG = True
 


### PR DESCRIPTION
## Summary

Wires payment-gated signup end-to-end on the backend. Form submit creates a Stripe Checkout Session; the webhook (on `checkout.session.completed`) is what actually creates the `User`, `Order`, chapter-1 grant, and fires the chapter-1 WhatsApp. Implementation follows the 5 locks in `plans/tickets/grilling/003.md`.

## File-by-file

| File | Change | Why |
|---|---|---|
| `core/services/__init__.py` | new (empty) | Package marker. Q1 lock established `core/services/` as the layer for business logic. |
| `core/services/payments.py` | new (~120 LOC) | The brain. `create_session` builds a Stripe Checkout Session with form fields stuffed into 6 separate metadata keys (Q3 lock), with the password `make_password`-hashed before it ever leaves the server. `verify_and_parse_event` wraps Stripe's signature check. `fulfill_checkout` runs idempotently (early-returns on existing `Order.stripe_session_id`), creates User + Order + chapter-1 grant inside a single `transaction.atomic` (Q5), then post-commit fires WhatsApp best-effort (logs + swallows on failure so a Twilio outage can't undo a payment). `login_from_session` is the helper for the welcome-page session bootstrap. |
| `core/services/grants.py` | new (~14 LOC) | T004's contract: `create_for_order(order) -> list[TemporalGrant]` (Q2 lock). Raises `NotImplementedError` until T004 ships — loud is better than silent. |
| `core/services/whatsapp.py` | new (~11 LOC) | T005's contract: `send_chapter(grant) -> None` (Q2 lock). Same stub posture. Best-effort wrapping in `fulfill_checkout` means this raising won't block fulfillment. |
| `core/schemas/payments.py` | new (~20 LOC) | Type-safe boundary per backend mandate #2: `CreateCheckoutSessionIn`, `CreateCheckoutSessionOut`, `SessionFromCheckoutIn`. |
| `core/api/payments.py` | new (~40 LOC) | Thin Ninja shells: `POST /api/payments/create-checkout-session` (returns 409 on duplicate email, 400 on unknown book) and `POST /api/payments/webhook` (returns 400 on bad signature, 200 on ignored events / idempotent replays). All business logic lives in the service module. |
| `core/api/auth.py` | +13 lines | Adds `POST /api/auth/session-from-checkout` (Q4 lock) — exchanges a Stripe `session_id` for a Django session cookie via `auth_login`. Idempotent. Drops a pre-existing unused `UserOut` import. |
| `core/api/__init__.py` | +2 lines | Registers the new `payments_router` on the Ninja API. |
| `sapien_backend/settings.py` | +6 lines | Reads `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, and `FRONTEND_URL` from env. Defaults are safe (empty / localhost). |
| `requirements.txt` | new (5 lines) | First requirements pin in this repo. Captures Django 6, Ninja 1.6, CORS, shortuuid, and the new `stripe>=12.0` dep. |
| `core/tests.py` | +218 lines | 10 new tests across `PaymentsApiTests` and `SessionFromCheckoutTests`. Covers all 4 acceptance criteria (idempotent replay no-ops, invalid signature → 400, duplicate email → 409, password hashed in metadata) plus happy paths, unknown-book 400, WhatsApp-failure-doesn't-block-200, and session-from-checkout 200/404. |

## Test plan

- [x] `python3 manage.py test core` → 27/27 pass
- [x] No new lint regressions; one pre-existing unused import dropped as drive-by
- [ ] `python3 manage.py makemigrations --check --dry-run` — **fails on pre-existing drift** unrelated to this PR. `core/models.py` uses `shortuuid.uuid` while migration 0002 recorded `shortuuid.main.ShortUUID.uuid`; Django's repr-based comparison treats these as different. Confirmed `git diff origin/master -- core/models.py core/migrations/` is empty for this branch. **Tracked separately as T015** in `plans/`.

## Notes for the reviewer

- The webhook-failure-mode design (Q5) intentionally distinguishes "fulfillment failed → must retry" from "notification failed → must not block payment." If `grants.create_for_order` raises (T004 not yet built), the atomic transaction rolls back User+Order, the webhook returns 5xx, Stripe retries. If `whatsapp.send_chapter` raises, fulfillment has already committed; the exception is logged and 200 still goes back to Stripe. Tests `test_webhook_idempotent_replay_noops` and `test_webhook_whatsapp_failure_does_not_block_200` lock these behaviors in.
- T015 (shortuuid drift) and T016 (env var doc + seed_demo command) were filed during this work and are queued in `plans/EXECUTION.md`. Neither is required to merge T003, but T016 is the natural unblocker for the next operator who wants to actually exercise this end-to-end with real Stripe test cards.

Closes sapien-paradox-devs/Sapien-Paradox-App-Services#3